### PR TITLE
fix: time.NewTicker method panics if argument is "<= 0"

### DIFF
--- a/prediction.go
+++ b/prediction.go
@@ -83,7 +83,7 @@ func (r *Client) GetPrediction(ctx context.Context, id string) (*Prediction, err
 // This function blocks until the prediction has finished, or the context is cancelled.
 // If the prediction has already finished, the prediction is returned immediately.
 // If the prediction has not finished after maxAttempts, an error is returned.
-// If interval is 0, the prediction is checked only once.
+// If interval is 1, the prediction is checked only once.
 // If interval is negative, an error is returned.
 // If maxAttempts is 0, there is no limit to the number of attempts.
 // If maxAttempts is negative, an error is returned.
@@ -92,8 +92,8 @@ func (r *Client) Wait(ctx context.Context, prediction Prediction, interval time.
 		return &prediction, nil
 	}
 
-	if interval < 0 {
-		return nil, errors.New("interval must be greater than or equal to zero")
+	if interval <= 0 {
+		return nil, errors.New("interval must be greater than zero")
 	}
 
 	if maxAttempts < 0 {

--- a/run.go
+++ b/run.go
@@ -30,7 +30,7 @@ func (r *Client) Run(ctx context.Context, identifier string, input PredictionInp
 		return nil, err
 	}
 
-	prediction, err = r.Wait(ctx, *prediction, 0, 0)
+	prediction, err = r.Wait(ctx, *prediction, 1, 0)
 
 	return prediction.Output, err
 }


### PR DESCRIPTION
# What's Problem
The current implementation in the Client.Run method passes zero to the interval argument of the Wait method 
https://github.com/replicate/replicate-go/blob/d6f3d9a0308e6b1481784631932d4f7652e7ee36/run.go#L33

This cause panic when initializing time.NewTicker.
https://github.com/replicate/replicate-go/blob/d6f3d9a0308e6b1481784631932d4f7652e7ee36/prediction.go#L103

Because time.NewTicker panics when its argument is a value less than or equal to zero.
```go
func NewTicker(d Duration) *Ticker {
	if d <= 0 {
		panic(errors.New("non-positive interval for NewTicker"))
	}
```
[tim.NewTicker()](https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/time/tick.go;l=22-25) 

# What I did
-  modify comment on the interval arg 
- If interval arg is  less than 0, returns error
- Changed the arg of the Client.Wait method in the Client.Run method to 1.