### PR TITLE
Remove nonexistent property `UpdatedAt` in `Prediction`

### DIFF
--- a/prediction.go
+++ b/prediction.go
@@ -29,7 +29,6 @@ type Prediction struct {
 	Webhook             *string            `json:"webhook,omitempty"`
 	WebhookEventsFilter []WebhookEventType `json:"webhook_events_filter,omitempty"`
 	CreatedAt           string             `json:"created_at"`
-	UpdatedAt           string             `json:"updated_at"`
 	StartedAt           *string            `json:"started_at,omitempty"`
 	CompletedAt         *string            `json:"completed_at,omitempty"`
 }

--- a/replicate_test.go
+++ b/replicate_test.go
@@ -244,7 +244,6 @@ func TestCreatePrediction(t *testing.T) {
 			Logs:      nil,
 			Metrics:   nil,
 			CreatedAt: "2022-04-26T22:13:06.224088Z",
-			UpdatedAt: "2022-04-26T22:13:06.224088Z",
 		}
 		responseBytes, err := json.Marshal(response)
 		if err != nil {
@@ -358,7 +357,6 @@ func TestGetPrediction(t *testing.T) {
 			Input:     replicate.PredictionInput{"text": "Alice"},
 			Output:    map[string]interface{}{"text": "Hello, Alice"},
 			CreatedAt: "2022-04-26T22:13:06.224088Z",
-			UpdatedAt: "2022-04-26T22:13:06.224088Z",
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -396,7 +394,6 @@ func TestWait(t *testing.T) {
 			Status:    statuses[i],
 			Input:     replicate.PredictionInput{"text": "Alice"},
 			CreatedAt: "2022-04-26T22:13:06.224088Z",
-			UpdatedAt: "2022-04-26T22:13:06.224088Z",
 		}
 
 		if statuses[i] == replicate.Succeeded {
@@ -424,7 +421,6 @@ func TestWait(t *testing.T) {
 		Status:    replicate.Starting,
 		Input:     replicate.PredictionInput{"text": "Alice"},
 		CreatedAt: "2022-04-26T22:13:06.224088Z",
-		UpdatedAt: "2022-04-26T22:13:06.224088Z",
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
A prediction has `created_at`, `started_at`, and `completed_at` timestamps, but no `updated_at` field.

See https://replicate.com/docs/reference/http