### PR TITLE
Update `Wait` to use functional options and add async variation

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,11 +23,11 @@ var (
 
 // Client is a client for the Replicate API.
 type Client struct {
-	options *options
+	options *clientOptions
 	c       *http.Client
 }
 
-type options struct {
+type clientOptions struct {
 	auth       string
 	baseURL    string
 	httpClient *http.Client
@@ -35,12 +35,12 @@ type options struct {
 }
 
 // ClientOption is a function that modifies an options struct.
-type ClientOption func(*options) error
+type ClientOption func(*clientOptions) error
 
 // NewClient creates a new Replicate API client.
 func NewClient(opts ...ClientOption) (*Client, error) {
 	c := &Client{
-		options: &options{
+		options: &clientOptions{
 			userAgent:  &defaultUserAgent,
 			baseURL:    defaultBaseURL,
 			httpClient: http.DefaultClient,
@@ -69,7 +69,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 
 // WithToken sets the auth token used by the client.
 func WithToken(token string) ClientOption {
-	return func(o *options) error {
+	return func(o *clientOptions) error {
 		o.auth = token
 		return nil
 	}
@@ -78,7 +78,7 @@ func WithToken(token string) ClientOption {
 // WithTokenFromEnv configures the client to use the auth token provided in the
 // REPLICATE_API_TOKEN environment variable.
 func WithTokenFromEnv() ClientOption {
-	return func(o *options) error {
+	return func(o *clientOptions) error {
 		token, ok := os.LookupEnv(envAuthToken)
 		if !ok {
 			return fmt.Errorf("%s environment variable not set", envAuthToken)
@@ -93,7 +93,7 @@ func WithTokenFromEnv() ClientOption {
 
 // WithUserAgent sets the User-Agent header on requests made by the client.
 func WithUserAgent(userAgent string) ClientOption {
-	return func(o *options) error {
+	return func(o *clientOptions) error {
 		o.userAgent = &userAgent
 		return nil
 	}
@@ -101,7 +101,7 @@ func WithUserAgent(userAgent string) ClientOption {
 
 // WithBaseURL sets the base URL for the client.
 func WithBaseURL(baseURL string) ClientOption {
-	return func(o *options) error {
+	return func(o *clientOptions) error {
 		o.baseURL = baseURL
 		return nil
 	}
@@ -109,7 +109,7 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // WithHTTPClient sets the HTTP client used by the client.
 func WithHTTPClient(httpClient *http.Client) ClientOption {
-	return func(o *options) error {
+	return func(o *clientOptions) error {
 		o.httpClient = httpClient
 		return nil
 	}

--- a/prediction.go
+++ b/prediction.go
@@ -2,9 +2,7 @@ package replicate
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"time"
 )
 
 type Source string
@@ -80,54 +78,4 @@ func (r *Client) GetPrediction(ctx context.Context, id string) (*Prediction, err
 		return nil, fmt.Errorf("failed to get prediction: %w", err)
 	}
 	return prediction, nil
-}
-
-// Wait for a prediction to finish.
-//
-// This function blocks until the prediction has finished, or the context is cancelled.
-// If the prediction has already finished, the prediction is returned immediately.
-// If the prediction has not finished after maxAttempts, an error is returned.
-// If interval is less than or equal to zero, an error is returned.
-// If maxAttempts is 0, there is no limit to the number of attempts.
-// If maxAttempts is negative, an error is returned.
-func (r *Client) Wait(ctx context.Context, prediction Prediction, interval time.Duration, maxAttempts int) (*Prediction, error) {
-	if prediction.Status.Terminated() {
-		return &prediction, nil
-	}
-
-	if interval <= 0 {
-		return nil, errors.New("interval must be greater than zero")
-	}
-
-	if maxAttempts < 0 {
-		return nil, errors.New("maxAttempts must be greater than or equal to zero")
-	}
-
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	id := prediction.ID
-
-	attempts := 0
-	for {
-		select {
-		case <-ticker.C:
-			prediction, err := r.GetPrediction(ctx, id)
-			if err != nil {
-				return nil, err
-			}
-
-			if prediction.Status.Terminated() {
-				return prediction, nil
-			}
-
-			attempts += 1
-			if maxAttempts > 0 && attempts > maxAttempts {
-				return nil, fmt.Errorf("prediction %s did not finish after %d attempts", id, maxAttempts)
-			}
-
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
 }

--- a/replicate_test.go
+++ b/replicate_test.go
@@ -433,6 +433,7 @@ func TestGetPrediction(t *testing.T) {
 
 func TestWait(t *testing.T) {
 	statuses := []replicate.Status{replicate.Starting, replicate.Processing, replicate.Succeeded}
+
 	i := 0
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
@@ -478,7 +479,7 @@ func TestWait(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	prediction, err = client.Wait(ctx, *prediction, time.Millisecond*100, 5)
+	err = client.Wait(ctx, prediction, replicate.WithInterval(1*time.Nanosecond))
 	assert.NoError(t, err)
 	assert.Equal(t, "ufawqhfynnddngldkgtslldrkq", prediction.ID)
 	assert.Equal(t, replicate.Succeeded, prediction.Status)

--- a/replicate_test.go
+++ b/replicate_test.go
@@ -487,6 +487,73 @@ func TestWait(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"text": "Hello, Alice"}, prediction.Output)
 }
 
+func TestWaitAsync(t *testing.T) {
+	statuses := []replicate.Status{replicate.Starting, replicate.Processing, replicate.Succeeded}
+
+	i := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "/predictions/ufawqhfynnddngldkgtslldrkq", r.URL.Path)
+
+		prediction := &replicate.Prediction{
+			ID:        "ufawqhfynnddngldkgtslldrkq",
+			Version:   "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
+			Status:    statuses[i],
+			Input:     replicate.PredictionInput{"text": "Alice"},
+			CreatedAt: "2022-04-26T22:13:06.224088Z",
+		}
+
+		if statuses[i] == replicate.Succeeded {
+			prediction.Output = map[string]interface{}{"text": "Hello, Alice"}
+		}
+
+		if i < len(statuses)-1 {
+			i++
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		body, _ := json.Marshal(prediction)
+		w.Write(body)
+	}))
+	defer mockServer.Close()
+
+	client, err := replicate.NewClient(
+		replicate.WithToken("test-token"),
+		replicate.WithBaseURL(mockServer.URL),
+	)
+	require.NoError(t, err)
+
+	prediction := &replicate.Prediction{
+		ID:        "ufawqhfynnddngldkgtslldrkq",
+		Version:   "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
+		Status:    replicate.Starting,
+		Input:     replicate.PredictionInput{"text": "Alice"},
+		CreatedAt: "2022-04-26T22:13:06.224088Z",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	predChan, errChan := client.WaitAsync(ctx, prediction, replicate.WithInterval(1*time.Nanosecond))
+	var lastStatus replicate.Status
+	for pred := range predChan {
+		lastStatus = pred.Status
+		if pred.Status == replicate.Succeeded {
+			assert.Equal(t, "ufawqhfynnddngldkgtslldrkq", pred.ID)
+			assert.Equal(t, replicate.PredictionInput{"text": "Alice"}, pred.Input)
+			assert.Equal(t, map[string]interface{}{"text": "Hello, Alice"}, pred.Output)
+			break
+		}
+	}
+
+	if err := <-errChan; err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, replicate.Succeeded, lastStatus)
+}
+
 func TestCreateTraining(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method)

--- a/run.go
+++ b/run.go
@@ -33,7 +33,7 @@ func (r *Client) Run(ctx context.Context, identifier string, input PredictionInp
 		return nil, err
 	}
 
-	prediction, err = r.Wait(ctx, *prediction, defaultPollingInterval, 0)
+	r.Wait(ctx, prediction)
 
 	return prediction.Output, err
 }

--- a/wait.go
+++ b/wait.go
@@ -83,3 +83,70 @@ func (r *Client) Wait(ctx context.Context, prediction *Prediction, opts ...WaitO
 		}
 	}
 }
+
+// WaitAsync returns a channel that receives the prediction as it progresses.
+//
+// The channel is closed when the prediction has finished, or the context is cancelled.
+// If the prediction has already finished, the channel is closed immediately.
+// If the prediction has not finished after maxAttempts, an error is sent to the error channel.
+// If interval is less than or equal to zero, an error is sent to the error channel.
+// If maxAttempts is less than zero, an error is sent to the error channel.
+// If maxAttempts is equal to zero, there is no limit to the number of attempts.
+func (r *Client) WaitAsync(ctx context.Context, prediction *Prediction, opts ...WaitOption) (<-chan *Prediction, <-chan error) {
+	predChan := make(chan *Prediction)
+	errChan := make(chan error)
+
+	options := &waitOptions{
+		interval: defaultInterval,
+	}
+
+	for _, option := range opts {
+		err := option(options)
+		if err != nil {
+			errChan <- err
+			close(predChan)
+			close(errChan)
+			return predChan, errChan
+		}
+	}
+
+	go func() {
+		defer close(predChan)
+		defer close(errChan)
+
+		ticker := time.NewTicker(options.interval)
+		defer ticker.Stop()
+
+		id := prediction.ID
+		attempts := 0
+		for {
+			select {
+			case <-ticker.C:
+				updatedPrediction, err := r.GetPrediction(ctx, id)
+				if err != nil {
+					errChan <- err
+					return
+				}
+
+				*prediction = *updatedPrediction
+				predChan <- updatedPrediction
+
+				if prediction.Status.Terminated() {
+					return
+				}
+
+				attempts += 1
+				if options.maxAttempts != nil && attempts >= *options.maxAttempts {
+					errChan <- fmt.Errorf("prediction %s did not finish after %d attempts", id, *options.maxAttempts)
+					return
+				}
+
+			case <-ctx.Done():
+				errChan <- ctx.Err()
+				return
+			}
+		}
+	}()
+
+	return predChan, errChan
+}

--- a/wait.go
+++ b/wait.go
@@ -2,57 +2,84 @@ package replicate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 )
 
+const (
+	defaultInterval = 1 * time.Second
+)
+
+type waitOptions struct {
+	interval    time.Duration
+	maxAttempts *int
+}
+
+// WaitOption is a function that modifies an options struct.
+type WaitOption func(*waitOptions) error
+
+// WithInterval sets the interval between attempts.
+func WithInterval(interval time.Duration) WaitOption {
+	return func(o *waitOptions) error {
+		o.interval = interval
+		return nil
+	}
+}
+
+// WithMaxAttempts sets the maximum number of attempts.
+func WithMaxAttempts(maxAttempts int) WaitOption {
+	return func(o *waitOptions) error {
+		o.maxAttempts = &maxAttempts
+		return nil
+	}
+}
+
 // Wait for a prediction to finish.
 //
 // This function blocks until the prediction has finished, or the context is cancelled.
-// If the prediction has already finished, the prediction is returned immediately.
+// If the prediction has already finished, the function returns immediately.
 // If the prediction has not finished after maxAttempts, an error is returned.
 // If interval is less than or equal to zero, an error is returned.
-// If maxAttempts is 0, there is no limit to the number of attempts.
-// If maxAttempts is negative, an error is returned.
-func (r *Client) Wait(ctx context.Context, prediction Prediction, interval time.Duration, maxAttempts int) (*Prediction, error) {
-	if prediction.Status.Terminated() {
-		return &prediction, nil
+// If maxAttempts is less than zero, an error is returned.
+// If maxAttempts is equal to zero, there is no limit to the number of attempts.
+func (r *Client) Wait(ctx context.Context, prediction *Prediction, opts ...WaitOption) error {
+	options := &waitOptions{
+		interval: defaultInterval,
 	}
 
-	if interval <= 0 {
-		return nil, errors.New("interval must be greater than zero")
+	for _, option := range opts {
+		err := option(options)
+		if err != nil {
+			return err
+		}
 	}
 
-	if maxAttempts < 0 {
-		return nil, errors.New("maxAttempts must be greater than or equal to zero")
-	}
-
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(options.interval)
 	defer ticker.Stop()
 
 	id := prediction.ID
-
 	attempts := 0
 	for {
 		select {
 		case <-ticker.C:
-			prediction, err := r.GetPrediction(ctx, id)
+			updatedPrediction, err := r.GetPrediction(ctx, id)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
+			*prediction = *updatedPrediction
+
 			if prediction.Status.Terminated() {
-				return prediction, nil
+				return nil
 			}
 
 			attempts += 1
-			if maxAttempts > 0 && attempts > maxAttempts {
-				return nil, fmt.Errorf("prediction %s did not finish after %d attempts", id, maxAttempts)
+			if options.maxAttempts != nil && attempts >= *options.maxAttempts {
+				return fmt.Errorf("prediction %s did not finish after %d attempts", id, *options.maxAttempts)
 			}
 
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return ctx.Err()
 		}
 	}
 }

--- a/wait.go
+++ b/wait.go
@@ -1,0 +1,58 @@
+package replicate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Wait for a prediction to finish.
+//
+// This function blocks until the prediction has finished, or the context is cancelled.
+// If the prediction has already finished, the prediction is returned immediately.
+// If the prediction has not finished after maxAttempts, an error is returned.
+// If interval is less than or equal to zero, an error is returned.
+// If maxAttempts is 0, there is no limit to the number of attempts.
+// If maxAttempts is negative, an error is returned.
+func (r *Client) Wait(ctx context.Context, prediction Prediction, interval time.Duration, maxAttempts int) (*Prediction, error) {
+	if prediction.Status.Terminated() {
+		return &prediction, nil
+	}
+
+	if interval <= 0 {
+		return nil, errors.New("interval must be greater than zero")
+	}
+
+	if maxAttempts < 0 {
+		return nil, errors.New("maxAttempts must be greater than or equal to zero")
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	id := prediction.ID
+
+	attempts := 0
+	for {
+		select {
+		case <-ticker.C:
+			prediction, err := r.GetPrediction(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+
+			if prediction.Status.Terminated() {
+				return prediction, nil
+			}
+
+			attempts += 1
+			if maxAttempts > 0 && attempts > maxAttempts {
+				return nil, fmt.Errorf("prediction %s did not finish after %d attempts", id, maxAttempts)
+			}
+
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}


### PR DESCRIPTION
Related to #6 

This PR updates the `Wait` function to use functional options instead of positional arguments. It also adds a `WaitAsync` variation that uses channels.