### PR TITLE
Add automatic retry policy

### DIFF
--- a/apierror.go
+++ b/apierror.go
@@ -1,12 +1,23 @@
 package replicate
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
 // APIError represents an error returned by the Replicate API
 type APIError struct {
 	Detail string `json:"detail"`
+}
+
+func unmarshalAPIError(data []byte) *APIError {
+	apiError := &APIError{}
+	err := json.Unmarshal(data, apiError)
+	if err != nil {
+		apiError.Detail = fmt.Sprintf("Unknown error: %s", err)
+	}
+
+	return apiError
 }
 
 // Error implements the error interface

--- a/backoff.go
+++ b/backoff.go
@@ -11,22 +11,26 @@ type Backoff interface {
 	NextDelay(retries int) time.Duration
 }
 
+// ConstantBackoff is a backoff strategy that returns a constant delay with some jitter.
 type ConstantBackoff struct {
 	Base   time.Duration
 	Jitter time.Duration
 }
 
+// NextDelay returns the next delay.
 func (b *ConstantBackoff) NextDelay(retries int) time.Duration {
 	jitter := time.Duration(rand.Float64() * float64(b.Jitter))
 	return b.Base + jitter
 }
 
+// ExponentialBackoff is a backoff strategy that returns an exponentially increasing delay with some jitter.
 type ExponentialBackoff struct {
 	Base       time.Duration
 	Multiplier float64
 	Jitter     time.Duration
 }
 
+// NextDelay returns the next delay.
 func (b *ExponentialBackoff) NextDelay(retries int) time.Duration {
 	jitter := time.Duration(rand.Float64() * float64(b.Jitter))
 	return time.Duration(float64(b.Base)*math.Pow(b.Multiplier, float64(retries))) + jitter

--- a/backoff.go
+++ b/backoff.go
@@ -1,0 +1,33 @@
+package replicate
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+// Backoff is an interface for backoff strategies.
+type Backoff interface {
+	NextDelay(retries int) time.Duration
+}
+
+type ConstantBackoff struct {
+	Base   time.Duration
+	Jitter time.Duration
+}
+
+func (b *ConstantBackoff) NextDelay(retries int) time.Duration {
+	jitter := time.Duration(rand.Float64() * float64(b.Jitter))
+	return b.Base + jitter
+}
+
+type ExponentialBackoff struct {
+	Base       time.Duration
+	Multiplier float64
+	Jitter     time.Duration
+}
+
+func (b *ExponentialBackoff) NextDelay(retries int) time.Duration {
+	jitter := time.Duration(rand.Float64() * float64(b.Jitter))
+	return time.Duration(float64(b.Base)*math.Pow(b.Multiplier, float64(retries))) + jitter
+}

--- a/client.go
+++ b/client.go
@@ -232,17 +232,13 @@ func (r *Client) request(ctx context.Context, method, path string, body interfac
 // shouldRetry returns true if the request should be retried.
 //
 // - GET requests should be retried if the response status code is 429 or 5xx.
-// - POST and PUT requests should be retried if the response status code is 429.
+// - Other requests should be retried if the response status code is 429.
 func (r *Client) shouldRetry(response *http.Response, method string) bool {
-	if response.StatusCode == 429 {
-		return true
-	}
-
 	if method == http.MethodGet {
-		return response.StatusCode < 500 || response.StatusCode >= 600
+		return response.StatusCode == 429 || (response.StatusCode >= 500 && response.StatusCode < 600)
 	}
 
-	return false
+	return response.StatusCode == 429
 }
 
 func constructURL(baseUrl, route string) string {

--- a/client.go
+++ b/client.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 )
 
 var (
@@ -17,6 +19,13 @@ var (
 
 	defaultUserAgent = "replicate/go" // TODO: embed version information
 	defaultBaseURL   = "https://api.replicate.com/v1"
+
+	defaultMaxRetries = 5
+	defaultBackoff    = &ExponentialBackoff{
+		Multiplier: 2,
+		Base:       500 * time.Millisecond,
+		Jitter:     50 * time.Millisecond,
+	}
 
 	ErrNoAuth = errors.New(`no auth token or token source provided -- perhaps you forgot to pass replicate.WithToken("...")`)
 )
@@ -27,11 +36,17 @@ type Client struct {
 	c       *http.Client
 }
 
+type retryPolicy struct {
+	maxRetries int
+	backoff    Backoff
+}
+
 type clientOptions struct {
-	auth       string
-	baseURL    string
-	httpClient *http.Client
-	userAgent  *string
+	auth        string
+	baseURL     string
+	httpClient  *http.Client
+	retryPolicy *retryPolicy
+	userAgent   *string
 }
 
 // ClientOption is a function that modifies an options struct.
@@ -41,8 +56,12 @@ type ClientOption func(*clientOptions) error
 func NewClient(opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		options: &clientOptions{
-			userAgent:  &defaultUserAgent,
-			baseURL:    defaultBaseURL,
+			userAgent: &defaultUserAgent,
+			baseURL:   defaultBaseURL,
+			retryPolicy: &retryPolicy{
+				maxRetries: defaultMaxRetries,
+				backoff:    defaultBackoff,
+			},
 			httpClient: http.DefaultClient,
 		},
 	}
@@ -115,6 +134,17 @@ func WithHTTPClient(httpClient *http.Client) ClientOption {
 	}
 }
 
+// WithRetryPolicy sets the retry policy used by the client.
+func WithRetryPolicy(maxRetries int, backoff Backoff) ClientOption {
+	return func(o *clientOptions) error {
+		o.retryPolicy = &retryPolicy{
+			maxRetries: maxRetries,
+			backoff:    backoff,
+		}
+		return nil
+	}
+}
+
 // request makes an HTTP request to the Replicate API.
 func (r *Client) request(ctx context.Context, method, path string, body interface{}, out interface{}) error {
 	bodyBuffer := &bytes.Buffer{}
@@ -138,33 +168,81 @@ func (r *Client) request(ctx context.Context, method, path string, body interfac
 		request.Header.Set("User-Agent", *r.options.userAgent)
 	}
 
-	response, err := r.c.Do(request)
-	if err != nil {
-		return fmt.Errorf("failed to make request: %w", err)
-	}
-	defer response.Body.Close()
+	maxRetries := r.options.retryPolicy.maxRetries
+	backoff := r.options.retryPolicy.backoff
 
-	responseBytes, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusBadRequest {
-		var apiError APIError
-		err := json.Unmarshal(responseBytes, &apiError)
+	var apiError *APIError
+	attempts := 0
+	for ok := true; ok; ok = attempts < maxRetries {
+		response, err := r.c.Do(request)
 		if err != nil {
-			return fmt.Errorf("unable to parse API error: %v", err)
+			return fmt.Errorf("failed to make request: %w", err)
 		}
+		defer response.Body.Close()
+
+		responseBytes, err := io.ReadAll(response.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %w", err)
+		}
+
+		if response.StatusCode < 200 || response.StatusCode >= 400 {
+			apiError = unmarshalAPIError(responseBytes)
+			if !r.shouldRetry(response, method) {
+				return apiError
+			}
+
+			delay := backoff.NextDelay(attempts)
+
+			retryAfter := response.Header.Get("Retry-After")
+			if retryAfter != "" {
+				if parsedDelay, parseErr := time.Parse(time.RFC1123, retryAfter); parseErr == nil {
+					delay = parsedDelay.Sub(time.Now())
+				} else if seconds, convErr := strconv.Atoi(retryAfter); convErr == nil {
+					delay = time.Duration(seconds) * time.Second
+				}
+			}
+
+			if delay > 0 {
+				time.Sleep(delay)
+			}
+
+			attempts++
+		} else {
+			if out != nil {
+				if err := json.Unmarshal(responseBytes, &out); err != nil {
+					return fmt.Errorf("failed to unmarshal response: %w", err)
+				}
+			}
+
+			return nil
+		}
+	}
+
+	if apiError != nil {
 		return apiError
 	}
 
-	if out != nil {
-		if err := json.Unmarshal(responseBytes, &out); err != nil {
-			return fmt.Errorf("failed to unmarshal response: %w", err)
-		}
+	if attempts > 0 {
+		return fmt.Errorf("request failed after %d attempts", maxRetries)
 	}
 
-	return nil
+	return fmt.Errorf("request failed")
+}
+
+// shouldRetry returns true if the request should be retried.
+//
+// - GET requests should be retried if the response status code is 429 or 5xx.
+// - POST and PUT requests should be retried if the response status code is 429.
+func (r *Client) shouldRetry(response *http.Response, method string) bool {
+	if response.StatusCode == 429 {
+		return true
+	}
+
+	if method == http.MethodGet {
+		return response.StatusCode < 500 || response.StatusCode >= 600
+	}
+
+	return false
 }
 
 func constructURL(baseUrl, route string) string {

--- a/replicate_test.go
+++ b/replicate_test.go
@@ -479,7 +479,7 @@ func TestWait(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err = client.Wait(ctx, prediction, replicate.WithInterval(1*time.Nanosecond))
+	err = client.Wait(ctx, prediction, replicate.WithPollingInterval(1*time.Nanosecond))
 	assert.NoError(t, err)
 	assert.Equal(t, "ufawqhfynnddngldkgtslldrkq", prediction.ID)
 	assert.Equal(t, replicate.Succeeded, prediction.Status)
@@ -535,7 +535,7 @@ func TestWaitAsync(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	predChan, errChan := client.WaitAsync(ctx, prediction, replicate.WithInterval(1*time.Nanosecond))
+	predChan, errChan := client.WaitAsync(ctx, prediction, replicate.WithPollingInterval(1*time.Nanosecond))
 	var lastStatus replicate.Status
 	for pred := range predChan {
 		lastStatus = pred.Status

--- a/run.go
+++ b/run.go
@@ -5,10 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"time"
 )
-
-const defaultPollingInterval = 1 * time.Second
 
 func (r *Client) Run(ctx context.Context, identifier string, input PredictionInput, webhook *Webhook) (PredictionOutput, error) {
 	namePattern := `[a-zA-Z0-9]+(?:(?:[._]|__|[-]*)[a-zA-Z0-9]+)*`

--- a/wait.go
+++ b/wait.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	defaultInterval = 1 * time.Second
+	defaultPollingInterval = 1 * time.Second
 )
 
 type waitOptions struct {
@@ -18,8 +18,8 @@ type waitOptions struct {
 // WaitOption is a function that modifies an options struct.
 type WaitOption func(*waitOptions) error
 
-// WithInterval sets the interval between attempts.
-func WithInterval(interval time.Duration) WaitOption {
+// WithPollingInterval sets the interval between attempts.
+func WithPollingInterval(interval time.Duration) WaitOption {
 	return func(o *waitOptions) error {
 		o.interval = interval
 		return nil
@@ -55,18 +55,17 @@ func (r *Client) Wait(ctx context.Context, prediction *Prediction, opts ...WaitO
 
 // WaitAsync returns a channel that receives the prediction as it progresses.
 //
-// The channel is closed when the prediction has finished, or the context is cancelled.
+// The channel is closed when the prediction has finished,
+// or the context is cancelled.
 // If the prediction has already finished, the channel is closed immediately.
-// If the prediction has not finished after maxAttempts, an error is sent to the error channel.
-// If interval is less than or equal to zero, an error is sent to the error channel.
-// If maxAttempts is less than zero, an error is sent to the error channel.
-// If maxAttempts is equal to zero, there is no limit to the number of attempts.
+// If polling interval is less than or equal to zero,
+// an error is sent to the error channel.
 func (r *Client) WaitAsync(ctx context.Context, prediction *Prediction, opts ...WaitOption) (<-chan *Prediction, <-chan error) {
 	predChan := make(chan *Prediction)
 	errChan := make(chan error)
 
 	options := &waitOptions{
-		interval: defaultInterval,
+		interval: defaultPollingInterval,
 	}
 
 	for _, option := range opts {


### PR DESCRIPTION
This PR introduces behavior to automatically retry them as appropriate (429 status code, as well as 5xx errors for GET requests). If the server sends a `Retry-After` header, that value is used. Otherwise, the function delays for the duration specified by the configured backoff strategy.

This should all be in line with the [retry logic in the Python client](https://github.com/replicate/replicate-python/blob/52f88eb3349c92c33608549ef992792172f951ed/replicate/client.py#L17-L63).