### PR TITLE
Store and retrieve raw JSON response from server

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -2,6 +2,7 @@ package replicate
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
@@ -10,6 +11,24 @@ type Collection struct {
 	Slug        string   `json:"slug"`
 	Description string   `json:"description"`
 	Models      *[]Model `json:"models,omitempty"`
+
+	rawJSON json.RawMessage `json:"-"`
+}
+
+func (c Collection) MarshalJSON() ([]byte, error) {
+	if c.rawJSON != nil {
+		return c.rawJSON, nil
+	} else {
+		type Alias Collection
+		return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&c)})
+	}
+}
+
+func (c *Collection) UnmarshalJSON(data []byte) error {
+	c.rawJSON = data
+	type Alias Collection
+	alias := &struct{ *Alias }{Alias: (*Alias)(c)}
+	return json.Unmarshal(data, alias)
 }
 
 // ListCollections returns a list of all collections.

--- a/model.go
+++ b/model.go
@@ -2,6 +2,7 @@ package replicate
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
@@ -18,6 +19,24 @@ type Model struct {
 	CoverImageURL  string        `json:"cover_image_url"`
 	DefaultExample *Prediction   `json:"default_example"`
 	LatestVersion  *ModelVersion `json:"latest_version"`
+
+	rawJSON json.RawMessage `json:"-"`
+}
+
+func (m Model) MarshalJSON() ([]byte, error) {
+	if m.rawJSON != nil {
+		return m.rawJSON, nil
+	} else {
+		type Alias Model
+		return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&m)})
+	}
+}
+
+func (m *Model) UnmarshalJSON(data []byte) error {
+	m.rawJSON = data
+	type Alias Model
+	alias := &struct{ *Alias }{Alias: (*Alias)(m)}
+	return json.Unmarshal(data, alias)
 }
 
 type ModelVersion struct {
@@ -25,6 +44,24 @@ type ModelVersion struct {
 	CreatedAt     string      `json:"created_at"`
 	CogVersion    string      `json:"cog_version"`
 	OpenAPISchema interface{} `json:"openapi_schema"`
+
+	rawJSON json.RawMessage `json:"-"`
+}
+
+func (m ModelVersion) MarshalJSON() ([]byte, error) {
+	if m.rawJSON != nil {
+		return m.rawJSON, nil
+	} else {
+		type Alias ModelVersion
+		return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&m)})
+	}
+}
+
+func (m *ModelVersion) UnmarshalJSON(data []byte) error {
+	m.rawJSON = data
+	type Alias ModelVersion
+	alias := &struct{ *Alias }{Alias: (*Alias)(m)}
+	return json.Unmarshal(data, alias)
 }
 
 // GetModel retrieves information about a model.

--- a/prediction.go
+++ b/prediction.go
@@ -2,6 +2,7 @@ package replicate
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -32,6 +33,24 @@ type Prediction struct {
 	CreatedAt           string             `json:"created_at"`
 	StartedAt           *string            `json:"started_at,omitempty"`
 	CompletedAt         *string            `json:"completed_at,omitempty"`
+
+	rawJSON json.RawMessage `json:"-"`
+}
+
+func (p Prediction) MarshalJSON() ([]byte, error) {
+	if p.rawJSON != nil {
+		return p.rawJSON, nil
+	} else {
+		type Alias Prediction
+		return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&p)})
+	}
+}
+
+func (p *Prediction) UnmarshalJSON(data []byte) error {
+	p.rawJSON = data
+	type Alias Prediction
+	alias := &struct{ *Alias }{Alias: (*Alias)(p)}
+	return json.Unmarshal(data, alias)
 }
 
 type PredictionProgress struct {


### PR DESCRIPTION
For the [CLI](https://github.com/replicate/cli), it'd be helpful to print the original JSON sent from the server. Currently, the Go objects are decoded from the server JSON and re-encoded into JSON, which would omit any fields that aren't accounted for in the model.

This PR adds an internal `rawJSON` field to structs, which stores the raw JSON message passed in `UnmarshalJSON`. If `rawJSON` isn't blank, `MarshalJSON` returns this value directly; otherwise, the object is marshaled normally.