### PR TITLE
Add support for `models.create` and `hardware.list` endpoints

### DIFF
--- a/hardware.go
+++ b/hardware.go
@@ -1,0 +1,40 @@
+package replicate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type Hardware struct {
+	SKU  string `json:"sku"`
+	Name string `json:"name"`
+
+	rawJSON json.RawMessage `json:"-"`
+}
+
+func (h Hardware) MarshalJSON() ([]byte, error) {
+	if h.rawJSON != nil {
+		return h.rawJSON, nil
+	} else {
+		type Alias Hardware
+		return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&h)})
+	}
+}
+
+func (h *Hardware) UnmarshalJSON(data []byte) error {
+	h.rawJSON = data
+	type Alias Hardware
+	alias := &struct{ *Alias }{Alias: (*Alias)(h)}
+	return json.Unmarshal(data, alias)
+}
+
+// ListHardware returns a list of available hardware.
+func (r *Client) ListHardware(ctx context.Context) (*[]Hardware, error) {
+	response := &[]Hardware{}
+	err := r.request(ctx, "GET", "/hardware", nil, response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list collections: %w", err)
+	}
+	return response, nil
+}

--- a/model.go
+++ b/model.go
@@ -39,6 +39,16 @@ func (m *Model) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, alias)
 }
 
+type CreateModelOptions struct {
+	Visibility    string  `json:"visibility"`
+	Hardware      string  `json:"hardware"`
+	Description   *string `json:"description,omitempty"`
+	GithubURL     *string `json:"github_url,omitempty"`
+	PaperURL      *string `json:"paper_url,omitempty"`
+	LicenseURL    *string `json:"license_url,omitempty"`
+	CoverImageURL *string `json:"cover_image_url,omitempty"`
+}
+
 type ModelVersion struct {
 	ID            string      `json:"id"`
 	CreatedAt     string      `json:"created_at"`
@@ -80,6 +90,27 @@ func (r *Client) GetModel(ctx context.Context, modelOwner string, modelName stri
 	err := r.request(ctx, "GET", fmt.Sprintf("/models/%s/%s", modelOwner, modelName), nil, model)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get model: %w", err)
+	}
+	return model, nil
+}
+
+// CreateModel creates a new model.
+func (r *Client) CreateModel(ctx context.Context, modelOwner string, modelName string, options CreateModelOptions) (*Model, error) {
+	model := &Model{}
+
+	body := struct {
+		Owner string `json:"owner"`
+		Name  string `json:"name"`
+		CreateModelOptions
+	}{
+		Owner:              modelOwner,
+		Name:               modelName,
+		CreateModelOptions: options,
+	}
+
+	err := r.request(ctx, "POST", "/models", body, model)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create model: %w", err)
 	}
 	return model, nil
 }


### PR DESCRIPTION
See https://replicate.com/docs/reference/http#models.create