### PR TITLE
Add support for `/predictions/{id}/cancel` endpoint

### DIFF
--- a/prediction.go
+++ b/prediction.go
@@ -142,6 +142,7 @@ func (r *Client) GetPrediction(ctx context.Context, id string) (*Prediction, err
 	return prediction, nil
 }
 
+// CancelPrediction cancels a running prediction by its ID.
 func (r *Client) CancelPrediction(ctx context.Context, id string) (*Prediction, error) {
 	prediction := &Prediction{}
 	err := r.fetch(ctx, "POST", fmt.Sprintf("/predictions/%s/cancel", id), nil, prediction)

--- a/prediction.go
+++ b/prediction.go
@@ -141,3 +141,12 @@ func (r *Client) GetPrediction(ctx context.Context, id string) (*Prediction, err
 	}
 	return prediction, nil
 }
+
+func (r *Client) CancelPrediction(ctx context.Context, id string) (*Prediction, error) {
+	prediction := &Prediction{}
+	err := r.fetch(ctx, "POST", fmt.Sprintf("/predictions/%s/cancel", id), nil, prediction)
+	if err != nil {
+		return nil, fmt.Errorf("failed to cancel prediction: %w", err)
+	}
+	return prediction, nil
+}

--- a/training.go
+++ b/training.go
@@ -31,6 +31,16 @@ func (r *Client) CreateTraining(ctx context.Context, model_owner string, model_n
 	return training, nil
 }
 
+// ListTrainings returns a list of trainings.
+func (r *Client) ListTrainings(ctx context.Context) (*Page[Training], error) {
+	response := &Page[Training]{}
+	err := r.fetch(ctx, "GET", "/trainings", nil, response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list trainings: %w", err)
+	}
+	return response, nil
+}
+
 // GetTraining sends a request to the Replicate API to get a training.
 func (r *Client) GetTraining(ctx context.Context, trainingID string) (*Training, error) {
 	training := &Training{}
@@ -51,14 +61,4 @@ func (r *Client) CancelTraining(ctx context.Context, trainingID string) (*Traini
 	}
 
 	return training, nil
-}
-
-// ListTrainings returns a list of trainings.
-func (r *Client) ListTrainings(ctx context.Context) (*Page[Training], error) {
-	response := &Page[Training]{}
-	err := r.fetch(ctx, "GET", "/trainings", nil, response)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list trainings: %w", err)
-	}
-	return response, nil
 }


### PR DESCRIPTION
This endpoint is missing for Go client although JS and Python SDK supports it. 