### PR TITLE
Add support for `DELETE /models/{modelOwner}/{modelName}/versions/{versionID}` endpoint

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -316,6 +316,32 @@ func TestCreateModel(t *testing.T) {
 	assert.Equal(t, "", model.Description)
 }
 
+func TestDeleteModelVersion(t *testing.T) {
+	modelName := "replicate"
+	modelOwner := "hello-world"
+	versionID := "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa"
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, fmt.Sprintf("/models/%s/%s/versions/%s", modelOwner, modelName, versionID), r.URL.Path)
+		w.WriteHeader(http.StatusAccepted)
+
+	}))
+	defer mockServer.Close()
+
+	client, err := replicate.NewClient(
+		replicate.WithToken("test-token"),
+		replicate.WithBaseURL(mockServer.URL),
+	)
+	require.NotNil(t, client)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = client.DeleteModelVersion(ctx, modelOwner, modelName, versionID)
+	assert.NoError(t, err)
+}
+
 func TestListModelVersions(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/models/replicate/hello-world/versions", r.URL.Path)

--- a/model.go
+++ b/model.go
@@ -136,7 +136,7 @@ func (r *Client) GetModelVersion(ctx context.Context, modelOwner string, modelNa
 	return version, nil
 }
 
-// DeleteModelVersion a model version and all associated predictions, including all output files.
+// DeleteModelVersion deletes a model version and all associated predictions, including all output files.
 func (r *Client) DeleteModelVersion(ctx context.Context, modelOwner string, modelName string, versionID string) error {
 	err := r.fetch(ctx, http.MethodDelete, fmt.Sprintf("/models/%s/%s/versions/%s", modelOwner, modelName, versionID), nil, nil)
 	if err != nil {

--- a/model.go
+++ b/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 )
 
 type Model struct {
@@ -133,6 +134,15 @@ func (r *Client) GetModelVersion(ctx context.Context, modelOwner string, modelNa
 		return nil, fmt.Errorf("failed to get model version: %w", err)
 	}
 	return version, nil
+}
+
+// DeleteModelVersion a model version and all associated predictions, including all output files.
+func (r *Client) DeleteModelVersion(ctx context.Context, modelOwner string, modelName string, versionID string) error {
+	err := r.fetch(ctx, http.MethodDelete, fmt.Sprintf("/models/%s/%s/versions/%s", modelOwner, modelName, versionID), nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete model version: %w", err)
+	}
+	return nil
 }
 
 // CreatePredictionWithModel sends a request to the Replicate API to create a prediction for a model.


### PR DESCRIPTION
This PR adds support for deleting a model version.

If I'm not mistaken, HTTP endpoint is currently not supported by either JS or Python client libraries.

It might be worth considering adding support for other client libraries as well.