### PR TITLE
Implement create prediction / training methods that take functional option arguments

### DIFF
--- a/deployment.go
+++ b/deployment.go
@@ -58,28 +58,12 @@ func (r *Client) GetDeployment(ctx context.Context, deployment_owner string, dep
 }
 
 // CreateDeploymentPrediction sends a request to the Replicate API to create a prediction using the specified deployment.
-func (r *Client) CreatePredictionWithDeployment(ctx context.Context, deployment_owner string, deployment_name string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {
-	data := map[string]interface{}{
-		"input": input,
+func (r *Client) CreatePredictionWithDeployment(ctx context.Context, deploymentOwner string, deploymentName string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {
+	opts := []CreatePredictionOption{
+		WithDeployment(deploymentOwner, deploymentName),
+		WithInput(input),
+		WithWebhook(webhook),
+		WithStream(stream),
 	}
-
-	if webhook != nil {
-		data["webhook"] = webhook.URL
-		if len(webhook.Events) > 0 {
-			data["webhook_events_filter"] = webhook.Events
-		}
-	}
-
-	if stream {
-		data["stream"] = true
-	}
-
-	prediction := &Prediction{}
-	path := fmt.Sprintf("/deployments/%s/%s/predictions", deployment_owner, deployment_name)
-	err := r.fetch(ctx, "POST", path, data, prediction)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create prediction: %w", err)
-	}
-
-	return prediction, nil
+	return r.CreatePredictionWithOptions(ctx, opts...)
 }

--- a/model.go
+++ b/model.go
@@ -137,26 +137,11 @@ func (r *Client) GetModelVersion(ctx context.Context, modelOwner string, modelNa
 
 // CreatePredictionWithModel sends a request to the Replicate API to create a prediction for a model.
 func (r *Client) CreatePredictionWithModel(ctx context.Context, modelOwner string, modelName string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {
-	data := map[string]interface{}{
-		"input": input,
+	opts := []CreatePredictionOption{
+		WithModel(modelOwner, modelName),
+		WithInput(input),
+		WithWebhook(webhook),
+		WithStream(stream),
 	}
-
-	if webhook != nil {
-		data["webhook"] = webhook.URL
-		if len(webhook.Events) > 0 {
-			data["webhook_events_filter"] = webhook.Events
-		}
-	}
-
-	if stream {
-		data["stream"] = true
-	}
-
-	prediction := &Prediction{}
-	err := r.fetch(ctx, "POST", fmt.Sprintf("/models/%s/%s/predictions", modelOwner, modelName), data, prediction)
-	if err != nil {
-		return nil, err
-	}
-
-	return prediction, nil
+	return r.CreatePredictionWithOptions(ctx, opts...)
 }

--- a/training.go
+++ b/training.go
@@ -8,6 +8,14 @@ import (
 type Training Prediction
 type TrainingInput PredictionInput
 
+type createTrainingBody struct {
+	Version             *string            `json:"version,omitempty"`
+	Input               TrainingInput      `json:"input"`
+	Webhook             *string            `json:"webhook,omitempty"`
+	WebhookEventsFilter []WebhookEventType `json:"webhook_events_filter,omitempty"`
+}
+type CreateTrainingOption func(path *string, body *createTrainingBody)
+
 // CreateTraining sends a request to the Replicate API to create a new training.
 func (r *Client) CreateTraining(ctx context.Context, model_owner string, model_name string, version string, destination string, input TrainingInput, webhook *Webhook) (*Training, error) {
 	data := map[string]interface{}{

--- a/training.go
+++ b/training.go
@@ -9,36 +9,85 @@ type Training Prediction
 type TrainingInput PredictionInput
 
 type createTrainingBody struct {
-	Version             *string            `json:"version,omitempty"`
+	Destination         *string            `json:"destination,omitempty"`
 	Input               TrainingInput      `json:"input"`
 	Webhook             *string            `json:"webhook,omitempty"`
 	WebhookEventsFilter []WebhookEventType `json:"webhook_events_filter,omitempty"`
 }
-type CreateTrainingOption func(path *string, body *createTrainingBody)
 
-// CreateTraining sends a request to the Replicate API to create a new training.
-func (r *Client) CreateTraining(ctx context.Context, model_owner string, model_name string, version string, destination string, input TrainingInput, webhook *Webhook) (*Training, error) {
-	data := map[string]interface{}{
-		"version":     version,
-		"destination": destination,
-		"input":       input,
-	}
+type CreateTrainingOption interface {
+	applyToCreateTrainingPath(*string)
+	applyToCreateTrainingBody(*createTrainingBody)
+}
 
-	if webhook != nil {
-		data["webhook"] = webhook.URL
-		if len(webhook.Events) > 0 {
-			data["webhook_events_filter"] = webhook.Events
+var _ CreateTrainingOption = withDestinationOption{}
+var _ CreateTrainingOption = withModelVersionOption{}
+var _ CreateTrainingOption = withInputOption{}
+var _ CreateTrainingOption = withWebhookOption{}
+
+//
+
+type withDestinationOption struct {
+	destination string
+}
+
+func (o withDestinationOption) applyToCreateTrainingPath(path *string) {}
+func (o withDestinationOption) applyToCreateTrainingBody(body *createTrainingBody) {
+	body.Destination = &o.destination
+}
+
+func WithDestination(destination string) CreateTrainingOption {
+	return withDestinationOption{destination: destination}
+}
+
+//
+
+func (o withModelVersionOption) applyToCreateTrainingPath(path *string) {
+	(*path) = fmt.Sprintf("/models/%s/%s/versions/%s/trainings", o.owner, o.name, o.version)
+}
+func (o withModelVersionOption) applyToCreateTrainingBody(body *createTrainingBody) {}
+
+func (o withInputOption) applyToCreateTrainingPath(path *string) {}
+func (o withInputOption) applyToCreateTrainingBody(body *createTrainingBody) {
+	body.Input = o.input
+}
+
+func (o withWebhookOption) applyToCreateTrainingPath(path *string) {}
+func (o withWebhookOption) applyToCreateTrainingBody(body *createTrainingBody) {
+	if o.webhook != nil {
+		body.Webhook = &o.webhook.URL
+		if len(o.webhook.Events) > 0 {
+			body.WebhookEventsFilter = o.webhook.Events
 		}
+	}
+}
+
+func (r *Client) CreateTrainingWithOptions(ctx context.Context, opts ...CreateTrainingOption) (*Training, error) {
+	path := "/trainings"
+	body := &createTrainingBody{}
+	for _, opt := range opts {
+		opt.applyToCreateTrainingPath(&path)
+		opt.applyToCreateTrainingBody(body)
 	}
 
 	training := &Training{}
-	path := fmt.Sprintf("/models/%s/%s/versions/%s/trainings", model_owner, model_name, version)
-	err := r.fetch(ctx, "POST", path, data, training)
+	err := r.fetch(ctx, "POST", path, body, training)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create training: %w", err)
 	}
 
 	return training, nil
+}
+
+// CreateTraining sends a request to the Replicate API to create a new training.
+func (r *Client) CreateTraining(ctx context.Context, modelOwner string, modelName string, version string, destination string, input TrainingInput, webhook *Webhook) (*Training, error) {
+	opts := []CreateTrainingOption{
+		WithModelVersion(modelOwner, modelName, version),
+		WithDestination(destination),
+		WithInput(input),
+		WithWebhook(webhook),
+	}
+	return r.CreateTrainingWithOptions(ctx, opts...)
 }
 
 // ListTrainings returns a list of trainings.


### PR DESCRIPTION
The method signature for `CreatePrediction` is less than ideal:

```go
func (r *Client) CreatePrediction(ctx context.Context, version string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {}
```

- It's too long. It takes too many arguments.
- It's inflexible. It can't accommodate future changes to requirements for creating a prediction. For example, creating predictions for a model without a version or for a deployment.
- Its last arguments are vague. There's no clue for what `nil` for webhook and `false` for stream mean at the call site.

This PR explores a new approach that uses functional arguments. For backwards compatibility, it adds new `CreatePredictionWithOptions` and `CreateTrainingWithOptions` methods, and ports the existing create methods to wrap them. In a future release, we could deprecate these older create methods and rename `CreatePredictionWithOptions` to `CreatePrediction`.

```go
import (
  context
  
  "github.com/replicate/replicate-go"
)

ctx := context.TODO()
input := replicate.PredictionInput{"prompt": "A fresh coat of paint"}
webhook := &replicate.Webhook{
	URL:    "https://example.com/webhook",
	Events: []replicate.WebhookEventType{"start", "completed"},
}
opts := []replicate.CreatePredictionOption{
	replicate.WithModel("owner", "model"),
	replicate.WithInput(input),
	replicate.WithWebhook(webhook),
	replicate.WithStream(true),
}
prediction, err := client.CreatePredictionWithOptions(ctx, opts...)
```