### PR TITLE
Replace custom `MarshalJSON` implementations with `RawJSON` instance method

### DIFF
--- a/account.go
+++ b/account.go
@@ -25,6 +25,8 @@ func (a Account) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&a)})
 }
 
+var _ json.Unmarshaler = (*Account)(nil)
+
 func (a *Account) UnmarshalJSON(data []byte) error {
 	a.rawJSON = data
 	type Alias Account

--- a/account.go
+++ b/account.go
@@ -16,13 +16,8 @@ type Account struct {
 	rawJSON json.RawMessage `json:"-"`
 }
 
-func (a Account) MarshalJSON() ([]byte, error) {
-	if a.rawJSON != nil {
-		return a.rawJSON, nil
-	}
-
-	type Alias Account
-	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&a)})
+func (a *Account) RawJSON() json.RawMessage {
+	return a.rawJSON
 }
 
 var _ json.Unmarshaler = (*Account)(nil)

--- a/collection.go
+++ b/collection.go
@@ -24,6 +24,8 @@ func (c Collection) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&c)})
 }
 
+var _ json.Unmarshaler = (*Collection)(nil)
+
 func (c *Collection) UnmarshalJSON(data []byte) error {
 	c.rawJSON = data
 	type Alias Collection

--- a/collection.go
+++ b/collection.go
@@ -16,12 +16,8 @@ type Collection struct {
 	rawJSON json.RawMessage `json:"-"`
 }
 
-func (c Collection) MarshalJSON() ([]byte, error) {
-	if c.rawJSON != nil {
-		return c.rawJSON, nil
-	}
-	type Alias Collection
-	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&c)})
+func (c *Collection) RawJSON() json.RawMessage {
+	return c.rawJSON
 }
 
 var _ json.Unmarshaler = (*Collection)(nil)

--- a/deployment.go
+++ b/deployment.go
@@ -30,12 +30,8 @@ type DeploymentConfiguration struct {
 	MaxInstances int    `json:"max_instances"`
 }
 
-func (d Deployment) MarshalJSON() ([]byte, error) {
-	if d.rawJSON != nil {
-		return d.rawJSON, nil
-	}
-	type Alias Deployment
-	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&d)})
+func (d *Deployment) RawJSON() json.RawMessage {
+	return d.rawJSON
 }
 
 var _ json.Unmarshaler = (*Deployment)(nil)

--- a/deployment.go
+++ b/deployment.go
@@ -38,6 +38,8 @@ func (d Deployment) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&d)})
 }
 
+var _ json.Unmarshaler = (*Deployment)(nil)
+
 func (d *Deployment) UnmarshalJSON(data []byte) error {
 	d.rawJSON = data
 	type Alias Deployment

--- a/files.go
+++ b/files.go
@@ -38,6 +38,10 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, alias)
 }
 
+func (f *File) RawJSON() json.RawMessage {
+	return f.rawJSON
+}
+
 type CreateFileOptions struct {
 	Filename    string            `json:"filename"`
 	ContentType string            `json:"content_type"`

--- a/files.go
+++ b/files.go
@@ -25,6 +25,17 @@ type File struct {
 	CreatedAt   string            `json:"created_at"`
 	ExpiresAt   string            `json:"expires_at"`
 	URLs        map[string]string `json:"urls"`
+
+	rawJSON json.RawMessage `json:"-"`
+}
+
+var _ json.Unmarshaler = (*File)(nil)
+
+func (f *File) UnmarshalJSON(data []byte) error {
+	f.rawJSON = data
+	type Alias File
+	alias := &struct{ *Alias }{Alias: (*Alias)(f)}
+	return json.Unmarshal(data, alias)
 }
 
 type CreateFileOptions struct {

--- a/hardware.go
+++ b/hardware.go
@@ -22,6 +22,8 @@ func (h Hardware) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&h)})
 }
 
+var _ json.Unmarshaler = (*Hardware)(nil)
+
 func (h *Hardware) UnmarshalJSON(data []byte) error {
 	h.rawJSON = data
 	type Alias Hardware

--- a/hardware.go
+++ b/hardware.go
@@ -14,12 +14,8 @@ type Hardware struct {
 	rawJSON json.RawMessage `json:"-"`
 }
 
-func (h Hardware) MarshalJSON() ([]byte, error) {
-	if h.rawJSON != nil {
-		return h.rawJSON, nil
-	}
-	type Alias Hardware
-	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&h)})
+func (h *Hardware) RawJSON() json.RawMessage {
+	return h.rawJSON
 }
 
 var _ json.Unmarshaler = (*Hardware)(nil)

--- a/model.go
+++ b/model.go
@@ -24,12 +24,8 @@ type Model struct {
 	rawJSON json.RawMessage `json:"-"`
 }
 
-func (m Model) MarshalJSON() ([]byte, error) {
-	if m.rawJSON != nil {
-		return m.rawJSON, nil
-	}
-	type Alias Model
-	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&m)})
+func (m *Model) RawJSON() json.RawMessage {
+	return m.rawJSON
 }
 
 var _ json.Unmarshaler = (*Model)(nil)
@@ -60,12 +56,8 @@ type ModelVersion struct {
 	rawJSON json.RawMessage `json:"-"`
 }
 
-func (m ModelVersion) MarshalJSON() ([]byte, error) {
-	if m.rawJSON != nil {
-		return m.rawJSON, nil
-	}
-	type Alias ModelVersion
-	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&m)})
+func (m *ModelVersion) RawJSON() json.RawMessage {
+	return m.rawJSON
 }
 
 var _ json.Unmarshaler = (*ModelVersion)(nil)

--- a/model.go
+++ b/model.go
@@ -32,6 +32,8 @@ func (m Model) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&m)})
 }
 
+var _ json.Unmarshaler = (*Model)(nil)
+
 func (m *Model) UnmarshalJSON(data []byte) error {
 	m.rawJSON = data
 	type Alias Model
@@ -65,6 +67,8 @@ func (m ModelVersion) MarshalJSON() ([]byte, error) {
 	type Alias ModelVersion
 	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&m)})
 }
+
+var _ json.Unmarshaler = (*ModelVersion)(nil)
 
 func (m *ModelVersion) UnmarshalJSON(data []byte) error {
 	m.rawJSON = data

--- a/paginate.go
+++ b/paginate.go
@@ -15,12 +15,8 @@ type Page[T any] struct {
 	rawJSON json.RawMessage `json:"-"`
 }
 
-func (p Page[T]) MarshalJSON() ([]byte, error) {
-	if p.rawJSON != nil {
-		return p.rawJSON, nil
-	}
-	type Alias Page[T]
-	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&p)})
+func (p *Page[T]) RawJSON() json.RawMessage {
+	return p.rawJSON
 }
 
 var _ json.Unmarshaler = (*Page[Prediction])(nil)

--- a/paginate.go
+++ b/paginate.go
@@ -23,6 +23,8 @@ func (p Page[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&p)})
 }
 
+var _ json.Unmarshaler = (*Page[Prediction])(nil)
+
 func (p *Page[T]) UnmarshalJSON(data []byte) error {
 	p.rawJSON = data
 	type Alias Page[T]

--- a/prediction.go
+++ b/prediction.go
@@ -37,12 +37,8 @@ type Prediction struct {
 	rawJSON json.RawMessage `json:"-"`
 }
 
-func (p Prediction) MarshalJSON() ([]byte, error) {
-	if p.rawJSON != nil {
-		return p.rawJSON, nil
-	}
-	type Alias Prediction
-	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&p)})
+func (p *Prediction) RawJSON() json.RawMessage {
+	return p.rawJSON
 }
 
 var _ json.Unmarshaler = (*Prediction)(nil)

--- a/prediction.go
+++ b/prediction.go
@@ -45,6 +45,8 @@ func (p Prediction) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct{ *Alias }{Alias: (*Alias)(&p)})
 }
 
+var _ json.Unmarshaler = (*Prediction)(nil)
+
 func (p *Prediction) UnmarshalJSON(data []byte) error {
 	p.rawJSON = data
 	type Alias Prediction

--- a/webhook.go
+++ b/webhook.go
@@ -43,6 +43,10 @@ type WebhookSigningSecret struct {
 	rawJSON json.RawMessage
 }
 
+func (wss *WebhookSigningSecret) RawJSON() json.RawMessage {
+	return wss.rawJSON
+}
+
 var _ json.Unmarshaler = (*WebhookSigningSecret)(nil)
 
 func (wss *WebhookSigningSecret) UnmarshalJSON(data []byte) error {

--- a/webhook.go
+++ b/webhook.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,6 +39,17 @@ func (w WebhookEventType) String() string {
 
 type WebhookSigningSecret struct {
 	Key string `json:"key"`
+
+	rawJSON json.RawMessage
+}
+
+var _ json.Unmarshaler = (*WebhookSigningSecret)(nil)
+
+func (wss *WebhookSigningSecret) UnmarshalJSON(data []byte) error {
+	wss.rawJSON = data
+	type Alias WebhookSigningSecret
+	alias := &struct{ *Alias }{Alias: (*Alias)(wss)}
+	return json.Unmarshal(data, alias)
 }
 
 // GetDefaultWebhookSecret gets the default webhook signing secret


### PR DESCRIPTION
#19 updated resources to store raw JSON content when unmarshaling from API responses. This allowed applications like the CLI, for example, to show any new fields that were added to the API but not yet reflected in the Go client library.

However, this can create some unexpected results if you attempt to re-encode a resource after making any changes. The current implementation of `MarshalJSON` would have any `rawJSON` value returned, if present, with no mechanism for invalidating or resetting state of any of the fields were modified.

This PR removes those `MarshalJSON` functions in favor of using the built-in marshaling based on the structures. To access the original JSON from the API response, you can now use the `RawJSON` method.