### PR TITLE
Use Bearer authorization scheme

### DIFF
--- a/client.go
+++ b/client.go
@@ -157,7 +157,7 @@ func (r *Client) newRequest(ctx context.Context, method, path string, body io.Re
 	}
 
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", fmt.Sprintf("Token %s", r.options.auth))
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", r.options.auth))
 	if r.options.userAgent != nil {
 		request.Header.Set("User-Agent", *r.options.userAgent)
 	}


### PR DESCRIPTION
Replicate's API now supports the standard [Bearer authentication scheme](https://swagger.io/docs/specification/authentication/bearer-authentication/). 

https://replicate.com/changelog/2024-04-03-bearer-tokens

For compatibility with existing clients, the existing `Token` scheme will be supported indefinitely. But going forward, the new `Bearer` scheme is preferred.