### PR TITLE
Reset HTTP request body after reading the stream during webhook validation

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1744,6 +1744,11 @@ func TestValidateWebhook(t *testing.T) {
 	isValid, err := replicate.ValidateWebhookRequest(req, testSecret)
 	require.NoError(t, err)
 	assert.True(t, isValid)
+
+	// Ensure that the request body is available after validation
+	bodyBytes, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, body, string(bodyBytes))
 }
 
 func TestGetDeployment(t *testing.T) {

--- a/webhook.go
+++ b/webhook.go
@@ -1,6 +1,7 @@
 package replicate
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -80,6 +81,9 @@ func ValidateWebhookRequest(req *http.Request, secret WebhookSigningSecret) (boo
 	if err != nil {
 		return false, fmt.Errorf("failed to read request body: %w", err)
 	}
+	defer req.Body.Close()
+
+	req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	body := string(bodyBytes)
 
 	signedContent := fmt.Sprintf("%s.%s.%s", id, timestamp, body)


### PR DESCRIPTION
Hi!

I couldn't find any contribution guidelines in the repository, so I've done my best to follow the existing conventions. If there are any issues with this contribution, please let me know.

To give a bit of context on the change: I started using the `ValidateWebhookRequest` function in the API I was developing. However, I encountered an issue where the HTTP request body was left empty after validation and I needed it for further processing. While I implemented a workaround on my end, I believe the proper solution is to reset the buffer inside the validation function to avoid interfering with any of the input data. More people might encounter this issue when the library is more widely used, so I thought I would attempt to make this change directly in the library. I look forward to your feedback!