### PR TITLE
Document and improve file APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ prediction, _ := r8.CreatePrediction(ctx, version, input, &webhook, false)
 _ = r8.Wait(ctx, prediction) // Wait for the prediction to finish
 ```
 
+Some models take file inputs.
+Use the `CreateFileFromPath`, `CreateFileFromBytes`, or `CreateFileFromBuffer` method
+to upload a file and pass it as a prediction input.
+
+```go
+// https://replicate.com/vaibhavs10/incredibly-fast-whisper
+version := "3ab86df6c8f54c11309d4d1f930ac292bad43ace52d10c80d87eb258b3c9f79c"
+
+file, _ := r8.CreateFileFromPath(ctx, "path/to/audio.mp3", nil)
+
+input := replicate.PredictionInput{
+	"audio": file,
+}
+prediction, _ := r8.CreatePrediction(ctx, version, input, nil, false)
+```
+
 ### Webhooks
 
 To prevent unauthorized requests, Replicate signs every webhook and its metadata with a unique key for each user or organization. You can use this signature to verify the webhook indeed comes from Replicate before you process it.

--- a/prediction.go
+++ b/prediction.go
@@ -104,6 +104,13 @@ func (p Prediction) Progress() *PredictionProgress {
 
 // CreatePrediction sends a request to the Replicate API to create a prediction.
 func (r *Client) CreatePrediction(ctx context.Context, version string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {
+	// Convert File objects in input to their "get" URL value
+	for key, value := range input {
+		if file, ok := value.(*File); ok {
+			input[key] = file.URLs["get"]
+		}
+	}
+
 	data := map[string]interface{}{
 		"version": version,
 		"input":   input,


### PR DESCRIPTION
Resolves #65 

This PR updates the README with an example of how to upload files for prediction inputs. It also improves the ergonomics of working with files by automatically converting `File` objects in `input` maps to their corresponding URL value.