### PR TITLE
Add support for `DELETE /models/{modelOwner}/{modelName}`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: test lint
 
 .PHONY: test
 test:
-	$(GO) test -v ./...
+	$(GO) test -v ./... -skip ^Example
 
 lint: lint-golangci lint-nilaway
 

--- a/client_test.go
+++ b/client_test.go
@@ -324,7 +324,6 @@ func TestDeleteModelVersion(t *testing.T) {
 		assert.Equal(t, http.MethodDelete, r.Method)
 		assert.Equal(t, fmt.Sprintf("/models/%s/%s/versions/%s", modelOwner, modelName, versionID), r.URL.Path)
 		w.WriteHeader(http.StatusAccepted)
-
 	}))
 	defer mockServer.Close()
 

--- a/client_test.go
+++ b/client_test.go
@@ -1586,6 +1586,7 @@ func TestListFiles(t *testing.T) {
 	assert.Equal(t, "2022-04-26T22:13:06.224088Z", file.CreatedAt)
 	assert.Equal(t, "https://api.replicate.com/v1/files/"+fileID, file.URLs["get"])
 }
+
 func TestGetFile(t *testing.T) {
 	fileID := "file-id"
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2252,6 +2253,30 @@ func TestUpdateDeployment(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteModel(t *testing.T) {
+	modelName := "replicate"
+	modelOwner := "hello-world"
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, fmt.Sprintf("/models/%s/%s", modelOwner, modelName), r.URL.Path)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer mockServer.Close()
+
+	client, err := replicate.NewClient(
+		replicate.WithToken("test-token"),
+		replicate.WithBaseURL(mockServer.URL),
+	)
+	require.NotNil(t, client)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = client.DeleteModel(ctx, modelOwner, modelName)
+	assert.NoError(t, err)
 }
 
 // Helper functions to create pointers for the UpdateDeploymentOptions fields

--- a/model.go
+++ b/model.go
@@ -110,6 +110,16 @@ func (r *Client) CreateModel(ctx context.Context, modelOwner string, modelName s
 	return model, nil
 }
 
+// DeleteModel deletes a model with no associated versions.
+func (r *Client) DeleteModel(ctx context.Context, modelOwner string, modelName string) error {
+	err := r.fetch(ctx, http.MethodDelete, fmt.Sprintf("/models/%s/%s", modelOwner, modelName), nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete model: %w", err)
+	}
+
+	return nil
+}
+
 // ListModelVersions lists the versions of a model.
 func (r *Client) ListModelVersions(ctx context.Context, modelOwner string, modelName string) (*Page[ModelVersion], error) {
 	response := &Page[ModelVersion]{}


### PR DESCRIPTION
This PR adds support for the deleting an "empty" model.

Removes the need to navigate to the dashboard to manually delete a empty model!

Along the way, 33c6d1a673733951393dd3860d389ccd64f53ece removes an empty line.