### PR TITLE
Remove unnecessary `stream` parameter for creating predictions

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -431,7 +431,6 @@ func TestCreatePrediction(t *testing.T) {
 		assert.Equal(t, map[string]interface{}{"text": "Alice"}, requestBody["input"])
 		assert.Equal(t, "https://example.com/webhook", requestBody["webhook"])
 		assert.Equal(t, []interface{}{"start", "completed"}, requestBody["webhook_events_filter"])
-		assert.Equal(t, true, requestBody["stream"])
 
 		response := replicate.Prediction{
 			ID:        "ufawqhfynnddngldkgtslldrkq",
@@ -512,9 +511,6 @@ func TestCreatePredictionWithDeployment(t *testing.T) {
 		if _, exists := requestBody["webhook_events_filter"]; exists {
 			assert.Fail(t, "webhook_events_filter should not be present")
 		}
-		if _, exists := requestBody["stream"]; exists {
-			assert.Fail(t, "stream should not be present")
-		}
 
 		response := replicate.Prediction{
 			ID:        "ufawqhfynnddngldkgtslldrkq",
@@ -590,7 +586,6 @@ func TestCreatePredictionWithModel(t *testing.T) {
 		assert.Equal(t, map[string]interface{}{"text": "Alice"}, requestBody["input"])
 		assert.Equal(t, "https://example.com/webhook", requestBody["webhook"])
 		assert.Equal(t, []interface{}{"start", "completed"}, requestBody["webhook_events_filter"])
-		assert.Equal(t, true, requestBody["stream"])
 
 		response := replicate.Prediction{
 			ID:        "ufawqhfynnddngldkgtslldrkq",
@@ -1352,7 +1347,6 @@ func TestStream(t *testing.T) {
 
 			assert.Equal(t, "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa", requestBody["version"])
 			assert.Equal(t, map[string]interface{}{"text": "Alice"}, requestBody["input"])
-			assert.Equal(t, true, requestBody["stream"])
 
 			response := replicate.Prediction{
 				ID:        "ufawqhfynnddngldkgtslldrkq",

--- a/deployment.go
+++ b/deployment.go
@@ -45,8 +45,10 @@ func (d *Deployment) UnmarshalJSON(data []byte) error {
 
 // CreateDeploymentPrediction sends a request to the Replicate API to create a prediction using the specified deployment.
 //
-// The stream parameter has no effect, as streaming is now enabled by default for all predictions. For more information, see https://replicate.com/changelog/2024-07-15-streams-always-available-stream-parameter-deprecated
-func (c *Client) CreatePredictionWithDeployment(ctx context.Context, deploymentOwner string, deploymentName string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {
+// Deprecated: The stream parameter is no longer used and will be removed in a future version.
+// Streaming is now enabled by default for all predictions.
+// For more information, see https://replicate.com/changelog/2024-07-15-streams-always-available-stream-parameter-deprecated
+func (c *Client) CreatePredictionWithDeployment(ctx context.Context, deploymentOwner string, deploymentName string, input PredictionInput, webhook *Webhook, _ bool) (*Prediction, error) {
 	data := map[string]interface{}{
 		"input": input,
 	}

--- a/deployment.go
+++ b/deployment.go
@@ -44,6 +44,8 @@ func (d *Deployment) UnmarshalJSON(data []byte) error {
 }
 
 // CreateDeploymentPrediction sends a request to the Replicate API to create a prediction using the specified deployment.
+//
+// The stream parameter has no effect, as streaming is now enabled by default for all predictions. For more information, see https://replicate.com/changelog/2024-07-15-streams-always-available-stream-parameter-deprecated
 func (c *Client) CreatePredictionWithDeployment(ctx context.Context, deploymentOwner string, deploymentName string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {
 	data := map[string]interface{}{
 		"input": input,

--- a/deployment.go
+++ b/deployment.go
@@ -56,10 +56,6 @@ func (c *Client) CreatePredictionWithDeployment(ctx context.Context, deploymentO
 		}
 	}
 
-	if stream {
-		data["stream"] = true
-	}
-
 	prediction := &Prediction{}
 	path := fmt.Sprintf("/deployments/%s/%s/predictions", deploymentOwner, deploymentName)
 	err := c.fetch(ctx, http.MethodPost, path, data, prediction)

--- a/model.go
+++ b/model.go
@@ -151,8 +151,10 @@ func (r *Client) DeleteModelVersion(ctx context.Context, modelOwner string, mode
 
 // CreatePredictionWithModel sends a request to the Replicate API to create a prediction for a model.
 //
-// The stream parameter has no effect, as streaming is now enabled by default for all predictions. For more information, see https://replicate.com/changelog/2024-07-15-streams-always-available-stream-parameter-deprecated
-func (r *Client) CreatePredictionWithModel(ctx context.Context, modelOwner string, modelName string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {
+// Deprecated: The stream parameter is no longer used and will be removed in a future version.
+// Streaming is now enabled by default for all predictions.
+// For more information, see https://replicate.com/changelog/2024-07-15-streams-always-available-stream-parameter-deprecated
+func (r *Client) CreatePredictionWithModel(ctx context.Context, modelOwner string, modelName string, input PredictionInput, webhook *Webhook, _ bool) (*Prediction, error) {
 	data := map[string]interface{}{
 		"input": input,
 	}

--- a/model.go
+++ b/model.go
@@ -162,10 +162,6 @@ func (r *Client) CreatePredictionWithModel(ctx context.Context, modelOwner strin
 		}
 	}
 
-	if stream {
-		data["stream"] = true
-	}
-
 	prediction := &Prediction{}
 	err := r.fetch(ctx, http.MethodPost, fmt.Sprintf("/models/%s/%s/predictions", modelOwner, modelName), data, prediction)
 	if err != nil {

--- a/model.go
+++ b/model.go
@@ -150,6 +150,8 @@ func (r *Client) DeleteModelVersion(ctx context.Context, modelOwner string, mode
 }
 
 // CreatePredictionWithModel sends a request to the Replicate API to create a prediction for a model.
+//
+// The stream parameter has no effect, as streaming is now enabled by default for all predictions. For more information, see https://replicate.com/changelog/2024-07-15-streams-always-available-stream-parameter-deprecated
 func (r *Client) CreatePredictionWithModel(ctx context.Context, modelOwner string, modelName string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {
 	data := map[string]interface{}{
 		"input": input,

--- a/prediction.go
+++ b/prediction.go
@@ -103,6 +103,8 @@ func (p Prediction) Progress() *PredictionProgress {
 }
 
 // CreatePrediction sends a request to the Replicate API to create a prediction.
+//
+// The stream parameter has no effect, as streaming is now enabled by default for all predictions. For more information, see https://replicate.com/changelog/2024-07-15-streams-always-available-stream-parameter-deprecated
 func (r *Client) CreatePrediction(ctx context.Context, version string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {
 	// Convert File objects in input to their "get" URL value
 	for key, value := range input {

--- a/prediction.go
+++ b/prediction.go
@@ -123,10 +123,6 @@ func (r *Client) CreatePrediction(ctx context.Context, version string, input Pre
 		}
 	}
 
-	if stream {
-		data["stream"] = true
-	}
-
 	prediction := &Prediction{}
 	err := r.fetch(ctx, http.MethodPost, "/predictions", data, prediction)
 	if err != nil {

--- a/prediction.go
+++ b/prediction.go
@@ -104,8 +104,10 @@ func (p Prediction) Progress() *PredictionProgress {
 
 // CreatePrediction sends a request to the Replicate API to create a prediction.
 //
-// The stream parameter has no effect, as streaming is now enabled by default for all predictions. For more information, see https://replicate.com/changelog/2024-07-15-streams-always-available-stream-parameter-deprecated
-func (r *Client) CreatePrediction(ctx context.Context, version string, input PredictionInput, webhook *Webhook, stream bool) (*Prediction, error) {
+// Deprecated: The stream parameter is no longer used and will be removed in a future version.
+// Streaming is now enabled by default for all predictions.
+// For more information, see https://replicate.com/changelog/2024-07-15-streams-always-available-stream-parameter-deprecated
+func (r *Client) CreatePrediction(ctx context.Context, version string, input PredictionInput, webhook *Webhook, _ bool) (*Prediction, error) {
 	// Convert File objects in input to their "get" URL value
 	for key, value := range input {
 		if file, ok := value.(*File); ok {


### PR DESCRIPTION
Streaming is now enabled by default for all predictions.

For more information, see https://replicate.com/changelog/2024-07-15-streams-always-available-stream-parameter-deprecated