### PR TITLE
Add support for `models.search` endpoint

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -3,6 +3,7 @@ package replicate_test
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/replicate/replicate-go"
 )
@@ -58,4 +59,27 @@ func ExampleClient_CreatePrediction() {
 
 	fmt.Println(prediction.Status)
 	// Output: succeeded
+}
+
+func ExampleClient_SearchModels() {
+	ctx := context.TODO()
+
+	r8, err := replicate.NewClient(replicate.WithTokenFromEnv())
+	if err != nil {
+		panic(err)
+	}
+
+	query := "llama"
+	modelsPage, err := r8.SearchModels(ctx, query)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, model := range modelsPage.Results {
+		if model.Owner == "meta" && strings.HasPrefix(model.Name, "meta-llama-3") {
+			fmt.Printf("Found Meta Llama 3 model")
+			break
+		}
+	}
+	// Output: Found Meta Llama 3 model
 }

--- a/model.go
+++ b/model.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 type Model struct {
@@ -75,6 +76,21 @@ func (r *Client) ListModels(ctx context.Context) (*Page[Model], error) {
 	err := r.fetch(ctx, http.MethodGet, "/models", nil, response)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list models: %w", err)
+	}
+	return response, nil
+}
+
+// SearchModels searches for public models.
+func (r *Client) SearchModels(ctx context.Context, query string) (*Page[Model], error) {
+	response := &Page[Model]{}
+	request, err := r.newRequest(ctx, "QUERY", "/models", strings.NewReader(query))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	request.Header.Set("Content-Type", "text/plain")
+	err = r.do(request, response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search models: %w", err)
 	}
 	return response, nil
 }


### PR DESCRIPTION
See https://replicate.com/docs/reference/http#models.search