### PR TITLE
Define and use default SSE type, `"message"`

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -18,6 +18,9 @@ var (
 )
 
 const (
+	// SSETypeDefault is the default type of SSEEvent.
+	SSETypeDefault = "message"
+
 	// SSETypeDone is the type of SSEEvent that indicates the prediction is done. The Data field will contain an empty JSON object.
 	SSETypeDone = "done"
 
@@ -202,7 +205,7 @@ func (r *Client) streamPrediction(ctx context.Context, prediction *Prediction, l
 					b := buf.Bytes()
 					buf.Reset()
 
-					event := SSEEvent{}
+					event := SSEEvent{Type: SSETypeDefault}
 					if err := event.decode(b); err != nil {
 						errChan <- err
 					}


### PR DESCRIPTION
According to the [HTML Standard](https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model), the default type for a server-sent event is `"message". This PR corrects the current behavior, which sets a zero value (`""`) if the event type isn't specified.