### PR TITLE
Update `Run` method to support versionless models

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ webhook := replicate.Webhook{
 	Events: []replicate.WebhookEventType{"start", "completed"},
 }
 
-// Run a model and wait for its output
+// Run a model by version and wait for its output
 output, _ := r8.Run(ctx, fmt.Sprintf("%s:%s", model, version), input, &webhook)
+
+// Run a model and wait for its output
+output, _ := r8.Run(ctx, model, input, &webhook)
 ```
 
 The `Run` method is a convenience method that

--- a/run.go
+++ b/run.go
@@ -55,18 +55,19 @@ func (r *Client) RunWithOptions(ctx context.Context, identifier string, input Pr
 		return nil, err
 	}
 
-	// Check if version is specified
-	if id.Version == nil {
-		return nil, errors.New("version must be specified")
-	}
-
 	// Prepare the data for the prediction request
-	data := map[string]interface{}{
-		"version": *id.Version,
+	data := map[string]interface{}{}
+	path := "/predictions"
+
+	// Set the model path or version in the data
+	if id.Version == nil {
+		path = "/models/" + id.Owner + "/" + id.Name + "/predictions"
+	} else {
+		data["version"] = *id.Version
 	}
 
 	// Create the prediction request
-	req, err := r.createPredictionRequest(ctx, "/predictions", data, input, webhook, false)
+	req, err := r.createPredictionRequest(ctx, path, data, input, webhook, false)
 	if err != nil {
 		return nil, err
 	}

--- a/run.go
+++ b/run.go
@@ -61,7 +61,7 @@ func (r *Client) RunWithOptions(ctx context.Context, identifier string, input Pr
 
 	// Set the model path or version in the data
 	if id.Version == nil {
-		path = "/models/" + id.Owner + "/" + id.Name + "/predictions"
+		path = fmt.Sprintf("/models/%s/%s/predictions", id.Owner, id.Name)
 	} else {
 		data["version"] = *id.Version
 	}


### PR DESCRIPTION
hye, It wasn't possible to call just "black-forest-labs/flux-schnell" model, official model wihtout version... now it is !