### PR TITLE
Fix behavior of `RunWithOptions` when wait is set

### DIFF
--- a/run.go
+++ b/run.go
@@ -82,10 +82,14 @@ func (r *Client) RunWithOptions(ctx context.Context, identifier string, input Pr
 		return nil, err
 	}
 
-	// Wait for the prediction to complete
-	err = r.Wait(ctx, prediction)
-	if err != nil {
-		return nil, err
+	// Check if the prediction is done based on blocking preference and status
+	isDone := options.blockUntilDone && prediction.Status != Starting
+	if !isDone {
+		// Wait for the prediction to complete
+		err = r.Wait(ctx, prediction)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Check for model error in the prediction


### PR DESCRIPTION
Follow-up to #82 

This PR brings the Go client in line with the JS client behavior updated by https://github.com/replicate/replicate-javascript/pull/315. Specifically, this updates the code for `RunWithOptions` to not poll if the `WithBlockUntilDone` option is passed and the prediction status isn't `"starting"`.