### PR TITLE
remove nilaway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,8 @@ all: test lint
 test:
 	$(GO) test -v ./... -skip ^Example
 
-lint: lint-golangci lint-nilaway
+lint: lint-golangci
 
 .PHONY: lint-golangci
 lint-golangci:
 	$(GO) run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2 run ./...
-
-.PHONY: lint-nilaway
-lint-nilaway:
-	$(GO) run go.uber.org/nilaway/cmd/nilaway@latest ./...


### PR DESCRIPTION
This is raising false positives.  http.Client#Do guarantees that the response is non-nil if err is nil.

See uber/nilaway#126.